### PR TITLE
Always use custom port when it is set

### DIFF
--- a/src/webpack/baseConfig.ts
+++ b/src/webpack/baseConfig.ts
@@ -18,14 +18,12 @@ const rootFolder = path.resolve(process.cwd());
 
 export async function createBaseConfig(cli: Settings['cli']): Promise<webpack.Configuration> {
   let port = 0;
-  if (!cli.isLibraryComponent) {
+  if (cli.port) {
+    port = cli.port;
+  } else if (!cli.isLibraryComponent) {
     port = 4321;
   } else {
-    if (!cli.port) {
-      port = 4320
-    } else {
-      port = cli.port;
-    }
+    port = 4320
   }
 
   await freePortIfInUse(port);

--- a/src/webpack/devServer.ts
+++ b/src/webpack/devServer.ts
@@ -8,11 +8,11 @@ import { logDebugString } from './helpers';
 
 export async function startDevServer() {
   const config = await resultConfig();
-  
+
   const compiler = Webpack(config);
   const server = new WebpackDevServer(compiler, config.devServer);
 
-  logDebugString(`To load your scripts, use this query string: ${colors.yellow('?debug=true&noredir=true&debugManifestsFile=https://localhost:4321/temp/manifests.js')}`);
+  logDebugString(`To load your scripts, use this query string: ${colors.yellow(`?debug=true&noredir=true&debugManifestsFile=https://${config.devServer.host}:${config.devServer.port}/temp/manifests.js`)}`);
 
   server.listen(config.devServer.port, config.devServer.host, (err) => {
     if (err) {


### PR DESCRIPTION
Current implementation does not allow to override port when the webparts or extentions components are used. This PR allows always use port provided by user in `fast-serve/config.json` file. If the port is not set in config file the next default port numbers are used:

- Library component - **4320**
- **Not** Library Compornent (WebParts or Extensions) - **4321**